### PR TITLE
Add support for OpenBSD

### DIFF
--- a/pidusage.go
+++ b/pidusage.go
@@ -58,12 +58,13 @@ func init() {
 	fnMap["darwin"] = wrapper("ps")
 	fnMap["sunos"] = wrapper("ps")
 	fnMap["freebsd"] = wrapper("ps")
+	fnMap["openbsd"] = wrapper("ps")
 	fnMap["aix"] = wrapper("ps")
 	fnMap["linux"] = wrapper("proc")
 	fnMap["netbsd"] = wrapper("proc")
 	fnMap["win"] = wrapper("win")
 
-	if platform == "linux" || platform == "netbsd" {
+	if platform == "linux" || platform == "netbsd" || platform == "openbsd" {
 		initProc()
 	}
 }

--- a/pidusage.go
+++ b/pidusage.go
@@ -58,7 +58,7 @@ func init() {
 	fnMap["darwin"] = wrapper("ps")
 	fnMap["sunos"] = wrapper("ps")
 	fnMap["freebsd"] = wrapper("ps")
-	fnMap["openbsd"] = wrapper("ps")
+	fnMap["openbsd"] = wrapper("proc")
 	fnMap["aix"] = wrapper("ps")
 	fnMap["linux"] = wrapper("proc")
 	fnMap["netbsd"] = wrapper("proc")


### PR DESCRIPTION
Before:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5176b2]

goroutine 12 [running]:
github.com/struCoder/pidusage.GetStat(...)
	/home/build/pidusage/pidusage.go:193
github.com/struCoder/pidusage.BenchmarkGetStat(0xc0000b4240)
	/home/build/pidusage/pidusage_test.go:12 +0x72
testing.(*B).runN(0xc0000b4240, 0x1)
	/usr/local/go/src/testing/benchmark.go:192 +0xeb
testing.(*B).run1.func1(0xc0000b4240)
	/usr/local/go/src/testing/benchmark.go:232 +0x57
created by testing.(*B).run1
	/usr/local/go/src/testing/benchmark.go:225 +0x7f
exit status 2
FAIL	github.com/struCoder/pidusage	0.098s

```
After:
```
go test -bench Get   
goos: openbsd
goarch: amd64
pkg: github.com/struCoder/pidusage
cpu: Intel(R) Core(TM) i5-5250U CPU @ 1.60GHz
BenchmarkGetStat 	  258110	      4490 ns/op
PASS
ok  	github.com/struCoder/pidusage	1.229s
```